### PR TITLE
Refactor AuthSplitLayout to use AppLogo component instead of AppLogoIcon

### DIFF
--- a/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/resources/js/layouts/auth/auth-split-layout.tsx
@@ -1,4 +1,4 @@
-import AppLogoIcon from '@/components/app-logo-icon';
+import AppLogo from '@/components/app-logo';
 import { Link } from '@inertiajs/react';
 import { type PropsWithChildren } from 'react';
 
@@ -13,10 +13,7 @@ export default function AuthSplitLayout({ children, title, description }: PropsW
             <div className="flex flex-col gap-4 p-6 md:p-10">
                 <div className="flex justify-center gap-2 md:justify-start">
                     <Link href="/" className="flex items-center gap-2 font-medium">
-                        <div className="bg-primary text-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
-                            <AppLogoIcon className="dark:text-primary-foreground size-4" />
-                        </div>
-                        Laravel Boilerplate
+                        <AppLogo />
                     </Link>
                 </div>
                 <div className="flex flex-1 items-center justify-center">


### PR DESCRIPTION
This pull request includes changes to the `resources/js/layouts/auth/auth-split-layout.tsx` file to update the logo component used in the authentication split layout.

Component update:

* Replaced the import of `AppLogoIcon` with `AppLogo` to use the new logo component. (`resources/js/layouts/auth/auth-split-layout.tsx`)
* Updated the JSX to replace the `AppLogoIcon` component and its surrounding div with the `AppLogo` component. (`resources/js/layouts/auth/auth-split-layout.tsx`)