### PR TITLE
Add authentication middleware to examples resource routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,7 @@ Route::get('/', function () {
     return Inertia::render('landing');
 })->name('home');
 
-Route::resource('examples', ExampleController::class);
+Route::resource('examples', ExampleController::class)->middleware(['auth']);
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {


### PR DESCRIPTION
This pull request introduces a middleware requirement for the `examples` resource routes to enhance security by ensuring only authenticated users can access them.

* Security enhancement:
  * [`routes/web.php`](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL18-R18): Added the `auth` middleware to the `examples` resource routes to restrict access to authenticated users only.